### PR TITLE
[#44] ✨ 공통 컴포넌트 RadioInput 컴포넌트 구현

### DIFF
--- a/src/components/common/input/RadioInput.tsx
+++ b/src/components/common/input/RadioInput.tsx
@@ -1,0 +1,30 @@
+import clsx from 'clsx'
+import React from 'react'
+
+interface RadioInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string
+}
+
+export const RadioInput = ({
+  label,
+  className = '',
+  checked,
+  disabled,
+  ...props
+}: RadioInputProps) => {
+  return (
+    <label
+      className={clsx(
+        'flex cursor-pointer items-center',
+        disabled && 'cursor-not-allowed opacity-50',
+        className
+      )}
+    >
+      <input type='radio' checked={checked} disabled={disabled} {...props} />
+      <span className='custom-radio'></span>
+      <span className='text-body-2 ml-4 h-22 font-normal leading-body2 text-gray-800'>
+        {label}
+      </span>
+    </label>
+  )
+}

--- a/src/components/common/input/RadioInput.tsx
+++ b/src/components/common/input/RadioInput.tsx
@@ -1,5 +1,7 @@
 import clsx from 'clsx'
 
+import { handleKeyDown } from '@/utils/handleKeyDown'
+
 interface RadioInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label: string
 }
@@ -9,19 +11,36 @@ export const RadioInput = ({
   className = '',
   checked,
   disabled,
+  onChange,
   ...props
 }: RadioInputProps): JSX.Element => {
+  const labelClass = clsx(
+    'flex cursor-pointer items-center',
+    disabled && 'cursor-not-allowed opacity-50',
+    className
+  )
+
   return (
-    <label
-      className={clsx(
-        'flex cursor-pointer items-center',
-        disabled && 'cursor-not-allowed opacity-50',
-        className
-      )}
-    >
+    <label className={labelClass}>
       <input type='radio' checked={checked} disabled={disabled} {...props} />
-      <span className='custom-radio'></span>
-      <span className='text-body-2 ml-4 h-22 font-normal leading-body2 text-gray-800'>
+      <span
+        role='radio'
+        tabIndex={0}
+        aria-checked={checked}
+        aria-label={'radio button'}
+        onKeyDown={e =>
+          handleKeyDown(
+            e,
+            () =>
+              onChange?.({
+                target: { checked: true, value: props.value },
+              } as any),
+            disabled
+          )
+        }
+        className='custom-radio'
+      />
+      <span className='text-body-2 ml-4 h-22 font-normal text-gray-800'>
         {label}
       </span>
     </label>

--- a/src/components/common/input/RadioInput.tsx
+++ b/src/components/common/input/RadioInput.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx'
-import React from 'react'
 
 interface RadioInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label: string
@@ -11,7 +10,7 @@ export const RadioInput = ({
   checked,
   disabled,
   ...props
-}: RadioInputProps) => {
+}: RadioInputProps): JSX.Element => {
   return (
     <label
       className={clsx(

--- a/src/stories/common/input/RadioInput.stories.ts
+++ b/src/stories/common/input/RadioInput.stories.ts
@@ -1,0 +1,21 @@
+import { fn } from '@storybook/test'
+
+import { RadioInput } from '@/components/common/input/RadioInput'
+
+export default {
+  title: 'Common/Input/RadioInput',
+  component: RadioInput,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['common', 'radio'],
+  args: {
+    onChange: fn(),
+  },
+}
+
+export const Default = {
+  args: {
+    label: '회사 ‧ 학교',
+  },
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,3 +14,21 @@ select {
   outline: 0;
   cursor: pointer;
 }
+
+input[type='radio'] {
+  display: none;
+}
+.custom-radio {
+  @apply relative inline-block h-20 w-20 cursor-pointer rounded-full border-[1.4px] border-solid border-gray-300;
+}
+.custom-radio::before {
+  content: '';
+  @apply absolute left-1/2 top-1/2 block h-12 w-12 -translate-x-1/2 -translate-y-1/2 rounded-full;
+}
+input[type='radio']:checked + .custom-radio {
+  @apply border-primary-normal;
+}
+
+input[type='radio']:checked + .custom-radio::before {
+  @apply bg-primary-normal;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -32,3 +32,7 @@ input[type='radio']:checked + .custom-radio {
 input[type='radio']:checked + .custom-radio::before {
   @apply bg-primary-normal;
 }
+
+label:focus-within .custom-radio {
+  @apply ring-1 ring-primary-normal;
+}

--- a/src/utils/handleKeyDown.ts
+++ b/src/utils/handleKeyDown.ts
@@ -1,0 +1,9 @@
+export const handleKeyDown = (
+  e: React.KeyboardEvent,
+  callback: () => void,
+  disabled?: boolean
+): void => {
+  if (e.key === 'Enter' && !disabled) {
+    callback()
+  }
+}


### PR DESCRIPTION
# 📌 PR 템플릿

### 🏷️ PR 타입 (PR Type)

> 아래 해당 사항에 체크해 주세요.

- [ ] 🐛 버그 수정 (Bugfix)
- [x] ✨ 기능 개발 (Feature)
- [ ] 🎨 코드 스타일 변경 (Code style update) - 포매팅, 로컬 변수 등
- [ ] ♻️ 리팩토링 (Refactoring) - 기능 변화 없음, API 변경 없음
- [ ] 🛠️ 빌드 관련 변경 (Build related changes)
- [ ] 📝 문서 내용 변경 (Documentation)
- [ ] 🔄 기타 (Other) - 설명 작성

---

### 📝 요약 (Summary)

> PR의 목적과 간단한 설명을 적어주세요.
`RadioInput` 컴포넌트 구현
---

### 🔍 상세 내용 (Describe your changes)

> 변경 사항을 구체적으로 작성해 주세요.

- `RadioInput` 구현 (스토리북 코드 작성은 어려움이 있어 생략 -> 추후에 추가 예정)

---

### 🔗 관련 이슈 또는 링크 (Issue Number or Link)

> 이슈 번호나 관련 링크가 있다면 추가해 주세요.
#44
---

### ✅ 체크리스트 (Checklist)

> PR 작성 시 아래 사항들을 점검해 주세요.

- [ ] 빌드가 성공적으로 되었나요?
- [ ] 코드에 주석을 추가했나요?
- [x] 모든 테스트가 통과했나요?
- [ ] 관련 문서가 업데이트되었나요?

---

### 📸 스크린샷 (선택 사항)

> 변경 사항이 UI와
<img width="329" alt="스크린샷 2024-11-15 오후 6 11 29" src="https://github.com/user-attachments/assets/11af42d9-ae94-4ee7-a545-4d8d2accef4b">
 관련이 있다면 스크린샷을 추가해 주세요.

---

### 📝 기타 사항

> PR과 관련된 기타 사항이 있다면 적어주세요.
```
./src/components/common/input/RadioInput.tsx
24:36  Warning: Replace `ml-4·h-22·font-normal·leading-body2` with `leading-body2·ml-4·h-22·font-normal`  prettier/prettier
```
빌드 시 이런 경고가 나오는데, 테일윈드 확장 (CSS InteliSense) 프로그램에서 자동으로 정리해주는 것과 맞지 않아서 나오는 것 같습니다.